### PR TITLE
add configurable httpClient constructor to Remote, extend support to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,11 @@ You'll call either get() or post() with the following arguments:
 ```
 // Instantiate the SDK Remote class:
 Remote remote = new Remote();
+
+// Instantiate the SDK Remote class with a RequestConfig - https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/client/config/RequestConfig.html:
+RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(1000).build();
+
+Remote remote = new Remote(requestConfig);
 // Call get() or post() with a URL:
 remote.get("http://schemas.learnosity.com/stable/questions/templates");
 
@@ -256,6 +261,13 @@ reqData = new HashMap<String,String>();
 reqData.put("limit", "10");
 
 DataApi dataApi = new DataApi("https://data.learnosity.com/latest/itembank/items", sec, consumerSecret, reqData, "get");
+
+// you can also configure the Data API with a requestConfig as above
+RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(1000).build();
+
+dataApi.modifyRequest(requestConfig);
+
+
 JSONObject response = dataApi.requestJSONObject();
 JSONObject res = new JSONObject(response.getString("body"));
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ DataApi dataApi = new DataApi("https://data.learnosity.com/latest/itembank/items
 // you can also configure the Data API with a requestConfig as above
 RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(1000).build();
 
-dataApi.modifyRequest(requestConfig);
+dataApi.setRequestConfig(requestConfig);
 
 
 JSONObject response = dataApi.requestJSONObject();

--- a/src/LearnositySdk/Request/DataApi.java
+++ b/src/LearnositySdk/Request/DataApi.java
@@ -6,6 +6,9 @@ import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import org.apache.http.client.config.RequestConfig;
+
+
 /**
  *--------------------------------------------------------------------------
  * Learnosity SDK - DataApi
@@ -131,11 +134,20 @@ public class DataApi
 		this.secret = secret;
 		this.action = action;
 	}
-	
+
 	/**
-	 * Function to make the post request
+	 * Function to modify the internal remote object based on a custom configuration
 	 * @return JSONObject containing the information of the request
 	 * @throws Exception
+	 */
+	
+	public void modifyRemote(RequestConfig requestConfig)
+	{
+		this.remote = new Remote(requestConfig);
+	}
+
+	/**
+	 * Function to make the post request
 	 */
 	public Remote request() throws Exception
 	{

--- a/src/LearnositySdk/Request/DataApi.java
+++ b/src/LearnositySdk/Request/DataApi.java
@@ -141,7 +141,7 @@ public class DataApi
 	 * @throws Exception
 	 */
 	
-	public void modifyRemote(RequestConfig requestConfig)
+	public void setRequestConfig(RequestConfig requestConfig)
 	{
 		this.remote = new Remote(requestConfig);
 	}

--- a/src/LearnositySdk/Request/Remote.java
+++ b/src/LearnositySdk/Request/Remote.java
@@ -66,7 +66,7 @@ public class Remote {
 	{
 		result = new HashMap<String,String>();
 		sb = new StringBuilder();
-		httpclient = HttpClients.createDefault();
+		this.setDefaultClient();
 	}
 	
 
@@ -118,6 +118,21 @@ public class Remote {
 		this.request(url, true);
 	}
 	
+	/**
+	 * Set some default values for timeouts, emulating what is in the php sdk.
+	 * Not setting redirects as that's enabled by default, with max redirects
+	 * set to 50.
+	 * Also not setting ssl verification as that is also enabled by default.
+	 */
+	private void setDefaultClient()
+	{
+		RequestConfig defaultRequestConfig = RequestConfig.custom()
+				.setConnectTimeout(40000)
+				.setSocketTimeout(40000)
+				.setConnectionRequestTimeout(10000)
+				.build();
+		this.httpclient = HttpClients.custom().setDefaultRequestConfig(defaultRequestConfig).build();
+	}
 	
 	/**
 	 * Makes the actual request

--- a/src/LearnositySdk/Request/Remote.java
+++ b/src/LearnositySdk/Request/Remote.java
@@ -12,6 +12,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.Header;
+import org.apache.http.client.config.RequestConfig;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -68,6 +69,17 @@ public class Remote {
 		httpclient = HttpClients.createDefault();
 	}
 	
+
+	/**
+	 * Alternate Constructor taking in requestConfig
+	 */
+	public Remote(RequestConfig requestConfig)
+	{
+		result = new HashMap<String,String>();
+		sb = new StringBuilder();
+		httpclient = HttpClients.custom().setDefaultRequestConfig(requestConfig).build();
+	}
+
 	/**
 	 * Make a get request to the specified url
 	 * 

--- a/src/LearnositySdk/Test/Test.java
+++ b/src/LearnositySdk/Test/Test.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import org.json.JSONObject;
 import org.json.JSONArray;
+import org.apache.http.client.config.RequestConfig;
 
 public class Test {
 	
@@ -33,9 +34,8 @@ public class Test {
 			securityMap.put("consumer_key", consumerKey);
 			securityMap.put("domain","localhost");
 			JSONArray items = new JSONArray();
-			items.put("bbf1380c-c75c-487c-90e3-18c7a36005d1");
-			items.put("7bd193b1-3dc7-4c4d-913d-0278accffd67");
-			items.put("99edf31b-8a7a-424b-8cba-f41795f55c19");
+			items.put("LEAR_1");
+			items.put("LEAR_2");
 			JSONObject data = new JSONObject();
 			data.put("items", items);
 		    
@@ -51,6 +51,7 @@ public class Test {
 			JSONObject req = new JSONObject();
 			req.put("activities", activities);
 			
+			RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(40000).build();
 			DataApi dataApi = new DataApi(endpoint, securityMap, consumerSecret, req, "set");
 			Remote remote = dataApi.request();
 			String body = remote.getBody();
@@ -132,6 +133,7 @@ public class Test {
 			
 			System.out.println("Testing data api call without request data, but with action");
 			dataApi = new DataApi("https://data.learnosity.com/stable/itembank/items", sec, consumerSecret, "get");
+			dataApi.setRequestConfig(requestConfig);
 			response = dataApi.requestJSONObject();
 			res = new JSONObject(response.getString("body"));
 			if ((response.getInt("statusCode") == 200 && res.getJSONObject("meta").getBoolean("status") != true) ||


### PR DESCRIPTION
…modify to Data API

@marklynch this is a quickly tested Java SDK modification to allow for a client to set timeouts, proxies etc. by passing a requestConfig into the HttpClient.

Would be worth seeing if anyone in the Sydney office has worked with this before to cast an eye over it - functionally it's fine, but I'm a little worried that because of the type of change it is, it could be problematic. Needs testing .