### PR TITLE
[BUG] Fix error when Data API "data" is object LRN-23437

### DIFF
--- a/src/test/java/learnositysdk/request/DataApiIT.java
+++ b/src/test/java/learnositysdk/request/DataApiIT.java
@@ -137,6 +137,22 @@ public class DataApiIT
 		/* Can't assert much here, expecting no exceptions... */
 	}
 
+	public void testGetQuestionsRecursive()
+		throws java.lang.Exception
+	{
+		String[] itemRefs = {"item_2", "item_3", "item_4"};
+		String endpoint = baseUrl + "/itembank/questions";
+		System.out.println("Testing Data API call to " + endpoint + " with recursive GET request");
+
+		request.put("item_references", itemRefs);
+		request.put("limit", "1");
+
+		dataApi = new DataApi(endpoint, securityMap, consumerSecret, request, "get");
+		dataApi.requestRecursive(new DataApiITCallback());
+
+		/* Can't assert much here, expecting no exceptions... */
+	}
+
 	private JSONObject assertDataApiRequestWorks(String endpoint, Map securityMap, String consumerSecret)
 		throws java.lang.Exception
 	{


### PR DESCRIPTION
Resolves type error for Data API Endpoints that return an Object instead
of the more common Array in the "data" field of the response. For
example, the itembank/questions endpoint when "item_references" is
specified in the request.