### PR TITLE
LRN-36320 Use multipart encoding for POST

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG JAVA_DIST=eclipse-temurin
 ARG JAVA_VERSION=11
 FROM ${JAVA_DIST}:${JAVA_VERSION}
 
-ENV MAVEN_VERSION=3.8.4
+ENV MAVEN_VERSION=3.8.6
 
 RUN apt-get update && apt-get install -y --no-install-recommends git make && \
     rm -rf /var/lib/apt/lists/* && \

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,10 @@ build:
 test: test-unit test-integration-env
 
 test-unit:
-	mvn test
+	mvn test $(MVN_OPTS)
 
 test-integration-env:
-	ENV=$(ENV) REGION=$(REGION) VER=$(VER) mvn integration-test
+	ENV=$(ENV) REGION=$(REGION) VER=$(VER) mvn integration-test $(MVN_OPTS)
 
 clean:
 	mvn clean

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpmime</artifactId>
+      <version>4.5.13</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
       <version>4.4.12</version>
     </dependency>
@@ -51,6 +56,11 @@
       <artifactId>junit-jupiter</artifactId>
       <version>5.5.2</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.5.3</version>
     </dependency>
   </dependencies>
 
@@ -73,8 +83,8 @@
             <arg>-Xlint:all,-options,-path</arg>
           </compilerArgs>
           <compilerVersion>1.8</compilerVersion>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 

--- a/src/main/java/learnositysdk/request/Remote.java
+++ b/src/main/java/learnositysdk/request/Remote.java
@@ -1,18 +1,19 @@
 package learnositysdk.request;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.http.client.utils.URLEncodedUtils;
-import org.apache.http.NameValuePair;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.Header;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.Header;
-import org.apache.http.client.config.RequestConfig;
+import org.apache.http.NameValuePair;
 
 import java.nio.charset.Charset;
 import java.util.Map;
@@ -150,7 +151,13 @@ public class Remote {
 
 		if (post) {
 			HttpPost httpPost = new HttpPost(url);
-			httpPost.setEntity(new UrlEncodedFormEntity(this.makeNameValueList(this.postData), "UTF-8"));
+			MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create();
+			for (Map.Entry<String, Object> entry: this.postData.entrySet()) {
+				String key = entry.getKey();
+				entityBuilder.addTextBody(key, entry.getValue().toString(),
+					key.equals("action") ? ContentType.TEXT_PLAIN : ContentType.APPLICATION_JSON);
+			}
+			httpPost.setEntity(entityBuilder.build());
 			httpRequest = httpPost;
 		} else {
 			httpRequest = new HttpGet(url);

--- a/src/test/java/learnositysdk/request/DataApiIT.java
+++ b/src/test/java/learnositysdk/request/DataApiIT.java
@@ -4,12 +4,18 @@ import java.util.UUID;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.json.JSONObject;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONPointer;
 import org.apache.http.client.config.RequestConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DataApiIT {
@@ -158,6 +164,23 @@ public class DataApiIT {
 		/* Can't assert much here, expecting no exceptions... */
 	}
 
+	@Disabled
+	@Test
+	public void testSessions()
+		throws java.lang.Exception
+	{
+		String endpoint = baseUrl + "/sessions";
+		System.out.println("Testing Data API call to " + endpoint + " with SET request");
+
+		Path fileName = Path.of("requestText.txt");
+		String str = Files.readString(fileName);
+		Map<String,Object> request = new ObjectMapper().readValue(str, HashMap.class);
+
+		JSONObject result = assertDataApiRequestWorks(endpoint, securityMap, consumerSecret, request, "set");
+		JSONPointer jp = JSONPointer.builder().append("data").append("job_reference").build();
+		assertTrue(result.query(jp) != null);
+	}
+
 	private JSONObject assertDataApiRequestWorks(String endpoint, Map securityMap, String consumerSecret)
 		throws java.lang.Exception
 	{
@@ -174,7 +197,7 @@ public class DataApiIT {
 	private JSONObject assertDataApiRequestWorks(String endpoint, Map securityMap, String consumerSecret, Map request, String action)
 		throws java.lang.Exception
 	{
-		dataApi = new DataApi(endpoint, securityMap, consumerSecret, request, "get");
+		dataApi = new DataApi(endpoint, securityMap, consumerSecret, request, action);
 		response = dataApi.requestJSONObject();
 		responseJson = new JSONObject(response.getString("body"));
 


### PR DESCRIPTION
This change currently forces all POST requests to use multipart encoding.

I added the ability to pass options to the Maven test invocation using the `MVN_OPTS` environment variable. To run a single test, you can use
```
make test-integration-env MVN_OPTS='-Dtest=DataApiIT#testSessions'
```
to run just the one test `DataApiIT.testSessions()`. It will run it twice, though, because Make and Maven are managing separate dependency graphs.