### PR TITLE
Update maven core dependancies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG JAVA_DIST=eclipse-temurin
 ARG JAVA_VERSION=11
 FROM ${JAVA_DIST}:${JAVA_VERSION}
 
-ENV MAVEN_VERSION=3.8.6
+ENV MAVEN_VERSION=3.8.8
 
 RUN apt-get update && apt-get install -y --no-install-recommends git make && \
     rm -rf /var/lib/apt/lists/* && \

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ There's more features, besides. See the detailed list of SDK features on the [re
 
 1. Runtime libraries for Java installed. We've used Eclipse Adoptium/Temurin 11 LTS (previously known as 'AdoptOpenJDK'). ([instructions](https://projects.eclipse.org/projects/adoptium.temurin/downloads))
 
-2. Maven installed ([instructions](https://maven.apache.org/download.cgi)). We tested on Maven 3.8.4.
+2. Maven installed ([instructions](https://maven.apache.org/download.cgi)). We tested on Maven 3.8.8.
 
 3. Docker installed (required for the example tutorial on this page). ([instructions](https://www.docker.com/get-started)). We tested on Docker version 3.x.
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.6.1</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
The Maven version set in the Dockerfile is no longer available so I have bumped up the version to 3.8.8 see https://github.com/Learnosity/learnosity-sdk-java/issues/58 

In the process I've bumped jackson-databind to the latest version as well 