### PR TITLE
Update all 3rd party dependencies with known vulnerabilities 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 target
 Dist
 .idea
+.vscode
 learnositysdk.iml
 .DS_Store
 */.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.13</version>
+      <version>1.15</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.8.1</version>
+      <version>3.17.0</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -44,12 +44,12 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
-      <version>4.4.12</version>
+      <version>4.4.15</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20231013</version>
+      <version>20240303</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.4.2</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 
@@ -178,6 +178,19 @@
             </fileset>
           </filesets>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>7.4.4</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.7</version>
+      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Bumps commons-io:commons-io from 2.7 to 2.14.0
Bumps commons-codec from 1.13 to 1.15
Bumps commons-lang3 from 3.8.1 to 3.17.0
Bumps org.apache.httpcomponents.httpcore from 4.4.12 to 4.4.15
Bumps org.json from 20231013 to 20240303
Bumps com.fasterxml.jackson.core.databind from 2.13.4.2 to 2.18.0
Adds org.owasp.dependency-check-maven

All tests run and pass